### PR TITLE
gh-7: Fix broken generated repo link.

### DIFF
--- a/{{cookiecutter.directory_name}}/README.rst
+++ b/{{cookiecutter.directory_name}}/README.rst
@@ -38,7 +38,7 @@ You can contribute using:
 
 - Github
 - `transifex <https://www.transifex.com/python-doc/public/>`_
-- Or just by opening `an issue on github <https://github.com/python/python-docs-{{cookiecutter.language}}fr/issues>`_
+- Or just by opening `an issue on github <https://github.com/python/python-docs-{{cookiecutter.language}}/issues>`_
 
 
 Contributing using Github


### PR DESCRIPTION
This PR fixes [a bug I noticed in the creation of the repo link](https://github.com/python/devguide/pull/871#issuecomment-1133121570) and closes #7.