### PR TITLE
Bump to 3.11.

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,14 +7,14 @@ IETF language code, lowercased, with dashes. like "pt-br", "fr", "ja",
 "zh-cn", and so on.
 
     $ git clone https://github.com/python/cpython.git
-    $ (cd cpython; git checkout 3.9)
+    $ (cd cpython; git checkout 3.11)
     $ pip install cookiecutter
     $ cookiecutter https://github.com/JulienPalard/python-docs-cookiecutter
     language [fr]: de
     directory_name [python-docs-de]:
     $ cd python-docs-de
     $ git init
-    $ git switch -c 3.9
+    $ git switch -c 3.11
     $ git add README.rst Makefile
     $ git commit -m "Initial commit"
     $ make merge

--- a/{{cookiecutter.directory_name}}/Makefile
+++ b/{{cookiecutter.directory_name}}/Makefile
@@ -26,7 +26,7 @@ CPYTHON_CURRENT_COMMIT := eec8e61992fb654d4cf58de4d727c18622b8303e
 CPYTHON_PATH := ../cpython/
 
 LANGUAGE := {{cookiecutter.language}}
-BRANCH := 3.9
+BRANCH := 3.11
 
 EXCLUDED := whatsnew/ c-api/
 

--- a/{{cookiecutter.directory_name}}/README.rst
+++ b/{{cookiecutter.directory_name}}/README.rst
@@ -1,7 +1,7 @@
 Translation of the Python Documentation — {{cookiecutter.language}}
 {% for _ in "Translation of the Python Documentation — " %}={% endfor %}{% for _ in cookiecutter.language %}={% endfor %}
 
-.. image:: https://travis-ci.org/python/python-docs-{{cookiecutter.language}}.svg?branch=3.7
+.. image:: https://travis-ci.org/python/python-docs-{{cookiecutter.language}}.svg?branch=3.11
   :target: https://travis-ci.org/python/python-docs-{{cookiecutter.language}}
 
 
@@ -74,8 +74,8 @@ Step by step:
     git remote add upstream https://github.com/python/python-docs-{{cookiecutter.language}}.git
 
 All the translations must be made on the latest release.
-We never translate on an oldest version, by example, the latest python release
-is python 3.7, we don't want to translate directly on the python 3.5 release.
+We never translate on an oldest version, by example, the latest Python release
+is Python 3.11, we don't want to translate directly on the Python 3.5 release.
 If needed translations would be backported on the oldest versions by the
 `documentation team <https://www.python.org/dev/peps/pep-8015/#documentation-team>`_.
 
@@ -84,10 +84,10 @@ Now you're ready to start a work session, each time you'll start a new task, sta
 .. code-block:: bash
 
     # To work, we'll need a branch, based on an up-to-date (freshly fetched)
-    # upstream/3.7 branch, let's say we'll work on glossary so we name
+    # upstream/3.11 branch, let's say we'll work on glossary so we name
     # the branch "glossary":
     git fetch upstream
-    git checkout -b glossary upstream/3.7
+    git checkout -b glossary upstream/3.11
 
     # You can now work on the file, typically using poedit,
     poedit directory/file.po


### PR DESCRIPTION
This PR updates several occurrences of `3.x` to `3.11`.

I'm not sure if this should be updated too, and to what commit.  Is this just the most recent commit or the one matching a specific release?  Can something like `HEAD` or `3.11` be used instead?
https://github.com/JulienPalard/python-docs-cookiecutter/blob/d73064c023f41b4a97ddb1cfbcafffd4fd22cc1f/%7B%7Bcookiecutter.directory_name%7D%7D/Makefile#L20-L24
